### PR TITLE
docs: fix typo in latest note

### DIFF
--- a/src/uuid.lua
+++ b/src/uuid.lua
@@ -24,9 +24,9 @@
 -- if available and hence reduce that problem (provided LuaSocket has been loaded before uuid).
 --
 -- **6-nov-2015 Please take note of this issue**; [https://github.com/Mashape/kong/issues/478](https://github.com/Mashape/kong/issues/478) 
--- It demonstrates the problem of using time as a random seed. Specifically when used from mutiple processes.
+-- It demonstrates the problem of using time as a random seed. Specifically when used from multiple processes.
 -- So make sure to seed only once, application wide. And to not have multiple processes do that
--- simultaneously (like nginx does for example)
+-- simultaneously (like nginx does for example).
 
 local M = {}
 local math = require('math')


### PR DESCRIPTION
Very minor but came through it and GitHub makes it too easy to propose changes:

+ muiple -> multiple
+ dot

---

On a side note, I have run some tests locally because I wanted to compare the performance between this Lua implementation and the C wrapping from [lua-uuid](https://github.com/Mashape/lua-uuid), and while doing so, I noticed that this module does not cache the functions attached to global variables it uses, especially `math.random`, but also others used in the bitwise and int2hex functions.

I have noticed that this simple code:

```lua
local uuid = require "uuid"
for i = 1, 1000000 do
  assert(uuid() ~= uuid())
end
```

runs in about 1 to 2 seconds faster with caching of the globals on an i7 Macbook 2013 with LuaJIT 2.0.4. Sample from the tests:

```bash
# without cached globals
$ time lua test.lua
lua test.lua  8.93s user 0.02s system 99% cpu 8.964 total
# with cached globals
$ time lua test.lua
lua test.lua  7.86s user 0.02s system 99% cpu 7.906 total
```

Would you accept a PR with those globals cached?