### PR TITLE
feat: seedonce function for seeding only once

### DIFF
--- a/src/uuid.lua
+++ b/src/uuid.lua
@@ -213,4 +213,18 @@ function M.seed()
   end
 end
 
+----------------------------------------------------------------------------
+-- This is workaround for OpenResty when it isn't possible to call seed() from `init_worker` context
+-- seedonce() shoud be called each time when you need to get new UUID.
+-- When it is called for the first time, it seeds random with seed() function.
+-- Each next call do nothing
+function M.seedonce()
+  if M.seeded ~= nil then
+    return M.seeded
+  end
+
+  M.seeded = M.seed()
+  return M.seeded
+end
+
 return setmetatable( M, { __call = function(self, hwaddr) return self.new(hwaddr) end} )


### PR DESCRIPTION
I use uuid library for generating UUIDs, but each second we got the same UUIDs. Unfortunately I can't add `uuid.seed()` call into `init_worker` context, so I wrote `uuid.seedonce()` function which controls if it was called before and seeds only on the first call.