### PR TITLE
Replace current RNG with SHA-256 based one (and some other changes)

### DIFF
--- a/src/bitwise.lua
+++ b/src/bitwise.lua
@@ -1,0 +1,144 @@
+-- Modified version of BitOp-lua (https://github.com/AlberTajuelo/bitop-lua)
+-- The following code is licensed under the MIT license. A copy of the license can be found below.
+--[[
+MIT License
+
+Copyright (c).  Licensed under the same terms as Lua (MIT).
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+]]
+local M = {}
+local floor = math.floor
+
+local MOD = 2 ^ 32
+local MODM = MOD - 1
+
+local function memoize(f)
+    local mt = {}
+    local t = setmetatable({}, mt)
+
+    function mt:__index(k)
+        local v = f(k)
+        t[k] = v
+        return v
+    end
+
+    return t
+end
+
+local function make_bitop_uncached(t, m)
+    local function bitop(a, b)
+        local res, p = 0, 1
+        while a ~= 0 and b ~= 0 do
+            local am, bm = a % m, b % m
+            res = res + t[am][bm] * p
+            a = (a - am) / m
+            b = (b - bm) / m
+            p = p * m
+        end
+        res = res + (a + b) * p
+        return res
+    end
+    return bitop
+end
+
+local function make_bitop(t)
+    local op1 = make_bitop_uncached(t, 2 ^ 1)
+    local op2 = memoize(function(a)
+        return memoize(function(b)
+            return op1(a, b)
+        end)
+    end)
+    return make_bitop_uncached(op2, 2 ^ (t.n or 1))
+end
+
+local bxor = make_bitop { [0] = { [0] = 0, [1] = 1 }, [1] = { [0] = 1, [1] = 0 }, n = 4 }
+
+local function band(a, b) return ((a + b) - bxor(a, b)) / 2 end
+
+local lshift, rshift
+
+lshift = function(a, disp) -- Lua5.2 inspired
+    if disp < 0 then return rshift(a, -disp) end
+    return (a * 2 ^ disp) % 2 ^ 32
+end
+
+rshift = function(a, disp) -- Lua5.2 insipred
+    if disp < 0 then return lshift(a, -disp) end
+    return floor(a % 2 ^ 32 / 2 ^ disp)
+end
+
+local function rrotate(x, disp) -- Lua5.2 inspired
+    disp = disp % 32
+    local low = band(x, 2 ^ disp - 1)
+    return rshift(x, disp) + lshift(low, 32 - disp)
+end
+
+
+local function bit32_bnot(x)
+    return (-1 - x) % MOD
+end
+M.bnot = bit32_bnot
+
+local function bit32_bxor(a, b, c, ...)
+    local z
+    if b then
+        a = a % MOD
+        b = b % MOD
+        z = bxor(a, b)
+        if c then
+            z = bit32_bxor(z, c, ...)
+        end
+        return z
+    elseif a then
+        return a % MOD
+    else
+        return 0
+    end
+end
+M.bxor = bit32_bxor
+
+local function bit32_band(a, b, c, ...)
+    local z
+    if b then
+        a = a % MOD
+        b = b % MOD
+        z = ((a + b) - bxor(a, b)) / 2
+        if c then
+            z = bit32_band(z, c, ...)
+        end
+        return z
+    elseif a then
+        return a % MOD
+    else
+        return MODM
+    end
+end
+M.band = bit32_band
+
+function M.rrotate(x, disp)
+    return rrotate(x % MOD, disp)
+end
+
+function M.rshift(x, disp)
+    if disp > 31 or disp < -31 then return 0 end
+    return rshift(x % MOD, disp)
+end
+
+return M

--- a/src/rand.lua
+++ b/src/rand.lua
@@ -1,0 +1,38 @@
+local sha256 = require("sha256")
+local rand = {}
+rand.__index = rand
+
+-- Converts a number into a 6-byte string. Max: (2^48)-1.
+local function num2s(l)
+    local s = ""
+    local n = 6
+    for i = 1, n do
+        local rem = l % 256
+        s = string.char(rem) .. s
+        l = (l - rem) / 256
+    end
+    return s
+end
+
+function rand.new(initstring) 
+    local self = setmetatable({}, rand)
+
+    self.counter = 0
+    self.initstring = (initstring or "") .. (tostring(os.time()) .. tostring({})) -- tostring({}) to take advanatage of ASLR
+
+    return self
+end
+
+function rand:Generate(extraData) 
+    extraData = extraData or ""
+    local stringToBeHashed = self.initstring .. num2s(self.counter) .. extraData
+    self.counter = self.counter + 1
+    local resultingBytes = sha256(stringToBeHashed)
+    return resultingBytes:sub(0, 16)
+end
+
+function rand:SetSeed(newSeed) 
+    self.initstring = newSeed
+end
+
+return rand

--- a/src/sha256.lua
+++ b/src/sha256.lua
@@ -1,0 +1,175 @@
+-- Lua SHA-256 code (http://lua-users.org/wiki/SecureHashAlgorithm), by Roberto Ierusalimschy
+-- The author of the code below stated that it is under the MIT license 
+-- (http://lua-users.org/lists/lua-l/2014-08/msg00628.html),
+-- but did not provide one. 
+
+-- SHA-256 code in Lua 5.2; based on the pseudo-code from
+-- Wikipedia (http://en.wikipedia.org/wiki/SHA-2)
+
+local bit32 = require("bitwise")
+
+local band, rrotate, bxor, rshift, bnot =
+    bit32.band, bit32.rrotate, bit32.bxor, bit32.rshift, bit32.bnot
+
+local string, setmetatable, assert = string, setmetatable, assert
+
+_ENV = nil
+
+-- Initialize table of round constants
+-- (first 32 bits of the fractional parts of the cube roots of the first
+-- 64 primes 2..311):
+local k = {
+    0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5,
+    0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+    0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
+    0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+    0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc,
+    0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+    0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7,
+    0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+    0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
+    0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+    0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3,
+    0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+    0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5,
+    0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+    0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
+    0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+}
+
+
+-- transform a string of bytes in a string of hexadecimal digits
+local function str2hexa(s)
+    local h = string.gsub(s, ".", function(c)
+        return string.format("%02x", string.byte(c))
+    end)
+    return h
+end
+
+
+-- transform number 'l' in a big-endian sequence of 'n' bytes
+-- (coded as a string)
+local function num2s(l, n)
+    local s = ""
+    for i = 1, n do
+        local rem = l % 256
+        s = string.char(rem) .. s
+        l = (l - rem) / 256
+    end
+    return s
+end
+
+-- transform the big-endian sequence of four bytes starting at
+-- index 'i' in 's' into a number
+local function s232num(s, i)
+    local n = 0
+    for i = i, i + 3 do
+        n = n * 256 + string.byte(s, i)
+    end
+    return n
+end
+
+
+-- append the bit '1' to the message
+-- append k bits '0', where k is the minimum number >= 0 such that the
+-- resulting message length (in bits) is congruent to 448 (mod 512)
+-- append length of message (before pre-processing), in bits, as 64-bit
+-- big-endian integer
+local function preproc(msg, len)
+    local extra = -(len + 1 + 8) % 64
+    len = num2s(8 * len, 8) -- original len in bits, coded
+    msg = msg .. "\128" .. string.rep("\0", extra) .. len
+    assert(#msg % 64 == 0)
+    return msg
+end
+
+
+local function initH256(H)
+    -- (first 32 bits of the fractional parts of the square roots of the
+    -- first 8 primes 2..19):
+    H[1] = 0x6a09e667
+    H[2] = 0xbb67ae85
+    H[3] = 0x3c6ef372
+    H[4] = 0xa54ff53a
+    H[5] = 0x510e527f
+    H[6] = 0x9b05688c
+    H[7] = 0x1f83d9ab
+    H[8] = 0x5be0cd19
+    return H
+end
+
+
+local function digestblock(msg, i, H)
+    -- break chunk into sixteen 32-bit big-endian words w[1..16]
+    local w = {}
+    for j = 1, 16 do
+        w[j] = s232num(msg, i + (j - 1) * 4)
+    end
+
+    -- Extend the sixteen 32-bit words into sixty-four 32-bit words:
+    for j = 17, 64 do
+        local v = w[j - 15]
+        local s0 = bxor(rrotate(v, 7), rrotate(v, 18), rshift(v, 3))
+        v = w[j - 2]
+        local s1 = bxor(rrotate(v, 17), rrotate(v, 19), rshift(v, 10))
+        w[j] = w[j - 16] + s0 + w[j - 7] + s1
+    end
+
+    -- Initialize hash value for this chunk:
+    local a, b, c, d, e, f, g, h =
+        H[1], H[2], H[3], H[4], H[5], H[6], H[7], H[8]
+
+    -- Main loop:
+    for i = 1, 64 do
+        local s0 = bxor(rrotate(a, 2), rrotate(a, 13), rrotate(a, 22))
+        local maj = bxor(band(a, b), band(a, c), band(b, c))
+        local t2 = s0 + maj
+        local s1 = bxor(rrotate(e, 6), rrotate(e, 11), rrotate(e, 25))
+        local ch = bxor(band(e, f), band(bnot(e), g))
+        local t1 = h + s1 + ch + k[i] + w[i]
+
+        h = g
+        g = f
+        f = e
+        e = d + t1
+        d = c
+        c = b
+        b = a
+        a = t1 + t2
+    end
+
+    -- Add (mod 2^32) this chunk's hash to result so far:
+    H[1] = band(H[1] + a)
+    H[2] = band(H[2] + b)
+    H[3] = band(H[3] + c)
+    H[4] = band(H[4] + d)
+    H[5] = band(H[5] + e)
+    H[6] = band(H[6] + f)
+    H[7] = band(H[7] + g)
+    H[8] = band(H[8] + h)
+end
+
+
+
+local function finalresult256(H)
+    -- Produce the final hash value (big-endian):
+    return
+        (num2s(H[1], 4) .. num2s(H[2], 4) .. num2s(H[3], 4) .. num2s(H[4], 4) ..
+            num2s(H[5], 4) .. num2s(H[6], 4) .. num2s(H[7], 4) .. num2s(H[8], 4))
+end
+
+local HH = {} -- to reuse
+
+local function hash256(msg)
+    msg = preproc(msg, #msg)
+    local H = initH256(HH)
+
+    -- Process the message in successive 512-bit (64 bytes) chunks:
+    for i = 1, #msg, 64 do
+        digestblock(msg, i, H)
+    end
+
+    return finalresult256(H)
+end
+
+return hash256

--- a/src/uuid.lua
+++ b/src/uuid.lua
@@ -147,7 +147,7 @@ end
 -- print("here's a new uuid: ",uuid())
 function M.seed()
   if _G.ngx ~= nil then
-    return M.randomseed(ngx.time() .. ngx.worker_pid() .. tostring({}))
+    return M.randomseed(ngx.time() .. ngx.worker.pid() .. tostring({}))
   elseif package.loaded["socket"] and package.loaded["socket"].gettime then
     return M.randomseed(package.loaded["socket"].gettime()*10000 .. tostring({}))
   else


### PR DESCRIPTION
I have implemented an SHA-256 based RNG in pure Lua. It provides more security than the built-in math.random, and allows for more complex seeding methods. Due to this, one of the changes implements deriving seeds from the `tostring` of a blank table, which will be unique on each run for systems that have ASLR enabled. Also, seeding the PRNG can now be done with any binary data.

Let me know what you think and if it's too overkill.