### PR TITLE
Add FFI generator for Windows

### DIFF
--- a/spec/rng_spec.lua
+++ b/spec/rng_spec.lua
@@ -64,6 +64,25 @@ describe("rng's", function()
 
 
 
+  describe("win_ffi()", function()
+
+    it("fails on Posix", function()
+      local old_package_config = package.config
+      finally(function()
+        package.config = old_package_config -- luacheck: ignore
+      end)
+      -- make it think this is Windows
+      package.config = "/" .. package.config:sub(2,-1) -- luacheck: ignore
+
+      local rng, err = require("uuid").rng.win_ffi()
+      assert.is.falsy(rng)
+      assert.is.equal("win-ffi is only available on Windows", err)
+    end)
+
+  end)
+
+
+
   describe("urandom()", function()
 
     it("generates 1 byte", function()

--- a/src/test.lua
+++ b/src/test.lua
@@ -1,4 +1,0 @@
-local uuid = require "uuid"
-print(uuid)
-uuid.set_rng(uuid.rng.win_ffi())
-print(uuid.v4())

--- a/src/test.lua
+++ b/src/test.lua
@@ -1,0 +1,4 @@
+local uuid = require "uuid"
+print(uuid)
+uuid.set_rng(uuid.rng.win_ffi())
+print(uuid.v4())

--- a/src/uuid/rng/init.lua
+++ b/src/uuid/rng/init.lua
@@ -81,6 +81,7 @@ end
 ----------------------------------------------------------------------------
 -- Returns an rng that implements Windows' RtlGenRandom function which is
 -- a good source of randomness on all modern versions of Windows.
+-- Requires LuaJIT or a LuaJIT-compatible FFI library.
 -- @treturn function A function that returns `n` random bytes, signature: `byte_string, err = func(n)`
 -- @usage
 -- local uuid = require "uuid"

--- a/src/uuid/rng/init.lua
+++ b/src/uuid/rng/init.lua
@@ -265,6 +265,13 @@ do
       end
     end
 
+    do -- try RtlGenRandom() via FFI on windows
+      local wf = rng.win_ffi()
+      if wf then
+        return wf(40)  -- this is crypto level, so good enough
+      end
+    end
+
     -- fallback to sha1 of a combination of values
     local seed = {
       unique_table_id,


### PR DESCRIPTION
Uses [`RtlGenRandom`](https://learn.microsoft.com/en-us/windows/win32/api/ntsecapi/nf-ntsecapi-rtlgenrandom) API call to securely generate random data in a vanilla LuaJIT environment.